### PR TITLE
Added EF Core interceptors for User service

### DIFF
--- a/src/Backend/Services/Users/Users.DataAccess/Interceptors/AuditInterceptor.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interceptors/AuditInterceptor.cs
@@ -28,7 +28,7 @@ public sealed class AuditInterceptor(
 
     private static void LogEntityChanges(DbContext? context, ILogger logger)
     {
-        if (context == null || !logger.IsEnabled(LogLevel.Information))
+        if (context is null || !logger.IsEnabled(LogLevel.Information))
             return;
 
         var entries = context.ChangeTracker.Entries<EntityBase>()

--- a/src/Backend/Services/Users/Users.DataAccess/Interceptors/AuditInterceptor.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interceptors/AuditInterceptor.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Users.DataAccess.Entities;
+
+namespace Users.DataAccess.Interceptors;
+
+public sealed class AuditInterceptor(
+    ILogger<AuditInterceptor> logger
+) : SaveChangesInterceptor
+{
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        LogEntityChanges(eventData.Context, logger);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        LogEntityChanges(eventData.Context, logger);
+        return ValueTask.FromResult(result);
+    }
+
+    private static void LogEntityChanges(DbContext? context, ILogger logger)
+    {
+        if (context == null || !logger.IsEnabled(LogLevel.Information))
+            return;
+
+        var entries = context.ChangeTracker.Entries<EntityBase>()
+            .Where(e =>
+                e.State is EntityState.Added
+                    or EntityState.Modified
+                    or EntityState.Deleted);
+
+        foreach (var entry in entries)
+            logger.LogInformation(
+                "Entity: {Entity}, Id: {Id}, State: {State}",
+                entry.Metadata.ClrType.Name,
+                entry.Entity.Id,
+                entry.State
+            );
+    }
+}

--- a/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
@@ -25,7 +25,7 @@ public class SaveChangesInterceptor : Microsoft.EntityFrameworkCore.Diagnostics.
 
     private void UpdateTimestamps(DbContext? context)
     {
-        if (context == null)
+        if (context is null)
             return;
 
         var entries = context.ChangeTracker.Entries<EntityBase>()

--- a/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
@@ -31,20 +31,18 @@ public class SaveChangesInterceptor : Microsoft.EntityFrameworkCore.Diagnostics.
         var entries = context.ChangeTracker.Entries<EntityBase>()
             .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified);
 
+        var utcNow = DateTimeOffset.UtcNow;
 
         foreach (var entry in entries)
-        {
             if (entry.State == EntityState.Added)
             {
-                entry.Entity.CreatedAt = DateTimeOffset.UtcNow;
-                entry.Entity.UpdatedAt = DateTimeOffset.UtcNow;
+                entry.Entity.CreatedAt = utcNow;
+                entry.Entity.UpdatedAt = utcNow;
             }
-            else 
+            else
             {
                 entry.Property(e => e.CreatedAt).IsModified = false;
-                entry.Entity.UpdatedAt = DateTimeOffset.UtcNow;
+                entry.Entity.UpdatedAt = utcNow;
             }
-        }
-
     }
 }

--- a/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interceptors/SaveChangesInterceptor.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Users.DataAccess.Entities;
+
+namespace Users.DataAccess.Interceptors;
+
+public class SaveChangesInterceptor : Microsoft.EntityFrameworkCore.Diagnostics.SaveChangesInterceptor
+{
+    public override InterceptionResult<int> SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result)
+    {
+        UpdateTimestamps(eventData.Context);
+        return base.SavingChanges(eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
+        CancellationToken cancellationToken = default)
+    {
+        UpdateTimestamps(eventData.Context);
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+
+    private void UpdateTimestamps(DbContext? context)
+    {
+        if (context == null)
+            return;
+
+        var entries = context.ChangeTracker.Entries<EntityBase>()
+            .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified);
+
+
+        foreach (var entry in entries)
+        {
+            if (entry.State == EntityState.Added)
+            {
+                entry.Entity.CreatedAt = DateTimeOffset.UtcNow;
+                entry.Entity.UpdatedAt = DateTimeOffset.UtcNow;
+            }
+            else 
+            {
+                entry.Property(e => e.CreatedAt).IsModified = false;
+                entry.Entity.UpdatedAt = DateTimeOffset.UtcNow;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
# Main changes:

- Added **TimestampInterceptor**:
  - Automatically sets `CreatedAt` and `UpdatedAt` for all entities inheriting from `EntityBase`.
  - Handles `Added` and `Modified` entity states.

- Added **AuditInterceptor**:
  - Logs entity changes (`Id` + `State`) for `Added`, `Modified`, and `Deleted` entity states.
  - Uses `ILogger` via primary constructor.
  

close #13 