### PR TITLE
Get rid of a unit of work

### DIFF
--- a/src/Backend/Services/Users/Users.DataAccess/DependencyInjection.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/DependencyInjection.cs
@@ -37,7 +37,7 @@ public static class DependencyInjection
                 .AddInterceptors(saveChangesInterceptor, auditInterceptor);
         });
 
-        services.AddScoped<IUserUnitOfWorkRepository, UserUnitOfWorkRepository>();
+        services.AddScoped<IUserRepository, UserRepository>();
 
         return services;
     }

--- a/src/Backend/Services/Users/Users.DataAccess/Interfaces/IRepository.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interfaces/IRepository.cs
@@ -5,7 +5,7 @@ public interface IRepository<TEntity> where TEntity : EntityBase
 {
     Task<TEntity?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
-    Task CreateAsync(TEntity entity);
-    Task UpdateAsync(TEntity entity);
-    Task DeleteAsync(TEntity entity);
+    Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default);
+    Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
+    Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default);
 }

--- a/src/Backend/Services/Users/Users.DataAccess/Interfaces/IUnitOfWork.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interfaces/IUnitOfWork.cs
@@ -1,6 +1,0 @@
-namespace Users.DataAccess.Interfaces;
-
-public interface IUnitOfWork
-{
-    Task SaveChangesAsync(CancellationToken cancellationToken = default);
-}

--- a/src/Backend/Services/Users/Users.DataAccess/Interfaces/IUserRepository.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Interfaces/IUserRepository.cs
@@ -2,7 +2,7 @@ using Users.DataAccess.Entities;
 
 namespace Users.DataAccess.Interfaces;
 
-public interface IUserUnitOfWorkRepository: IRepository<User>, IUnitOfWork
+public interface IUserRepository : IRepository<User>
 {
     Task<User?> GetByAuth0UserIdAsync(string auth0UserId, CancellationToken cancellationToken = default);
 }

--- a/src/Backend/Services/Users/Users.DataAccess/Repositories/Repository.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Repositories/Repository.cs
@@ -1,6 +1,6 @@
+using Microsoft.EntityFrameworkCore;
 using Users.DataAccess.Entities;
 using Users.DataAccess.Interfaces;
-using Microsoft.EntityFrameworkCore;
 
 namespace Users.DataAccess.Repositories;
 
@@ -8,8 +8,8 @@ public class Repository<TEntity>(ApplicationDbContext context) : IRepository<TEn
 {
     protected readonly ApplicationDbContext _context = context;
     protected readonly DbSet<TEntity> _dbSet = context.Set<TEntity>();
-    
-    public async Task<TEntity?> GetByIdAsync(Guid id ,CancellationToken cancellationToken = default)
+
+    public async Task<TEntity?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         return await _dbSet.FindAsync([id], cancellationToken);
     }
@@ -19,24 +19,24 @@ public class Repository<TEntity>(ApplicationDbContext context) : IRepository<TEn
         return await _dbSet.ToListAsync(cancellationToken);
     }
 
-    public Task CreateAsync(TEntity entity)
+    public async Task CreateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
         _dbSet.Add(entity);
-        
-        return Task.CompletedTask;
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public Task UpdateAsync(TEntity entity)
+    public async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
         _dbSet.Update(entity);
-        
-        return Task.CompletedTask;
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public  Task DeleteAsync(TEntity entity)
+    public async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
     {
         _dbSet.Remove(entity);
-        
-        return Task.CompletedTask;
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Backend/Services/Users/Users.DataAccess/Repositories/UserRepository.cs
+++ b/src/Backend/Services/Users/Users.DataAccess/Repositories/UserRepository.cs
@@ -4,8 +4,8 @@ using Users.DataAccess.Interfaces;
 
 namespace Users.DataAccess.Repositories;
 
-public class UserUnitOfWorkRepository(ApplicationDbContext context)
-    : Repository<User>(context), IUserUnitOfWorkRepository
+public class UserRepository(ApplicationDbContext context)
+    : Repository<User>(context), IUserRepository
 {
     public async Task<User?> GetByAuth0UserIdAsync(
         string auth0UserId,
@@ -13,10 +13,5 @@ public class UserUnitOfWorkRepository(ApplicationDbContext context)
     {
         return await _dbSet
             .FirstOrDefaultAsync(u => u.Auth0UserId == auth0UserId, cancellationToken);
-    }
-    
-    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-    {
-        return _context.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
Main changes:

- Removed the UnitOfWork abstraction from the Users service

- Moved persistence responsibility into repositories (auto-commit on write operations)