### PR TITLE
Add throwing UserNotFoundException in GetUserByIdAsync

### DIFF
--- a/src/Backend/Services/Users/Users.Business/Interfaces/IUserService.cs
+++ b/src/Backend/Services/Users/Users.Business/Interfaces/IUserService.cs
@@ -8,7 +8,7 @@ public interface IUserService
         CreateUserDto createUserDto,
         CancellationToken cancellationToken = default);
 
-    public Task<GetUserDto?> GetUserByIdAsync(
+    public Task<GetUserDto> GetUserByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default);
 

--- a/src/Backend/Services/Users/Users.Business/Services/UserService.cs
+++ b/src/Backend/Services/Users/Users.Business/Services/UserService.cs
@@ -69,12 +69,14 @@ public class UserService(
         await _userRepository.DeleteAsync(user, cancellationToken);
     }
 
-    public async Task<GetUserDto?> GetUserByIdAsync(
+    public async Task<GetUserDto> GetUserByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default)
     {
-        var user = await _userRepository.GetByIdAsync(id, cancellationToken);
-        return user?.Adapt<GetUserDto>();
+        var user = await _userRepository.GetByIdAsync(id, cancellationToken)
+                   ?? throw new UserNotFoundException(id.ToString(), IdentitySources.Internal);
+
+        return user.Adapt<GetUserDto>();
     }
 
     public async Task<GetUserDto?> GetUserByIdentityIdAsync(


### PR DESCRIPTION
### Main changes:
- `GetUserByIdAsync` now throws `UserNotFoundException` instead of returning `null`.
- Removed nullable return type in `GetUserByIdAsync` and updated `IUserService` interface accordingly.
- Internal methods (`ActivateUserAsync`, `DeactivateUserAsync`, `DeleteUserAsync`) use `GetExistingUserAsync` to avoid code duplication.